### PR TITLE
Fixed display of aliases in help

### DIFF
--- a/DiscordCoreBotApple/src/com/demod/dcba/CommandDefinition.java
+++ b/DiscordCoreBotApple/src/com/demod/dcba/CommandDefinition.java
@@ -25,6 +25,17 @@ public class CommandDefinition {
 		return aliases;
 	}
 
+	public String getAliasesString(String commandPrefix) {
+		String ret = "";
+		if (aliases.isPresent()) {
+			for (String alias : aliases.get()) {
+				ret += ", ``" + commandPrefix + alias + "``";
+			}
+		}
+
+		return ret;
+	}
+
 	public CommandHandler getHandler() {
 		return handler;
 	}


### PR DESCRIPTION
This changes the general help display. Before:
![Before](https://user-images.githubusercontent.com/27060268/78503559-a746e700-7767-11ea-8467-f981d71d4f11.png)

After:
![After](https://user-images.githubusercontent.com/27060268/78503564-b332a900-7767-11ea-8f14-0168024a05eb.png)

Before, including broken alias display:
![Broken alias](https://user-images.githubusercontent.com/27060268/78503580-e1b08400-7767-11ea-9493-768f3dc62aec.png)
