### PR TITLE
Update Maven compiler plugin to 3.14.0

### DIFF
--- a/DiscordCoreBotApple/pom.xml
+++ b/DiscordCoreBotApple/pom.xml
@@ -11,7 +11,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.14.0</version>
 				<configuration>
 					<source>11</source>
 					<target>11</target>


### PR DESCRIPTION
3.5.1 is not capable for Java11.